### PR TITLE
Use latest hugo.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:edge
+FROM alpine:latest
 
-ENV HUGO_VERSION 0.63.1
+ENV HUGO_VERSION 0.66.0
 
 LABEL description="hugo cryptocommons build"
 LABEL version="1.0"
@@ -9,7 +9,7 @@ LABEL maintainer="jholdstock@decred.org"
 WORKDIR /tmp
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache wget libc6-compat g++
+RUN apk add --no-cache bash wget libc6-compat g++
 RUN wget -q https://github.com/gohugoio/hugo/releases/download/v$HUGO_VERSION/hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
 RUN tar xz -C /usr/local/bin -f hugo_extended_"$HUGO_VERSION"_Linux-64bit.tar.gz
 


### PR DESCRIPTION
- Use latest alpine image rather than edge. We don't need the bleeding edge release which may include untested or broken functionality